### PR TITLE
fix api change parsec >=3.1.6

### DIFF
--- a/src/Data/Rewriting/Substitution/Parse.hs
+++ b/src/Data/Rewriting/Substitution/Parse.hs
@@ -18,6 +18,7 @@ import Data.Rewriting.Substitution.Type
 import qualified Data.Rewriting.Term.Parse as Term
 import Control.Monad
 import Text.Parsec hiding (parse)
+import Text.Parsec.Prim (runP)
 
 
 parse :: (Ord v) =>

--- a/src/Data/Rewriting/Term/Parse.hs
+++ b/src/Data/Rewriting/Term/Parse.hs
@@ -19,6 +19,7 @@ import Control.Monad
 import Control.Monad.Error ()
 import Data.Rewriting.Term.Type
 import Text.Parsec hiding (parse)
+import Text.Parsec.Prim (runP)
 
 -- | Like 'fromString', but the result is wrapped in the IO monad, making this
 -- function useful for interactive testing.

--- a/term-rewriting.cabal
+++ b/term-rewriting.cabal
@@ -62,7 +62,7 @@ library
     build-depends:
         containers >= 0.3 && < 0.6,
         multiset >= 0.2 && < 0.3,
-        parsec >= 3 && < 3.2,
+        parsec >= 3.1.6 && < 3.2,
         union-find-array >= 0.1 && < 0.2,
         array >= 0.3 && < 0.6,
         ansi-wl-pprint >= 0.6 && < 0.7,


### PR DESCRIPTION
In `parsec` >=3.1.6 module `Text.Parsec` does not export `runP`.
