### PR TITLE
compute normal forms w.r.t. given strategy

### DIFF
--- a/src/Data/Rewriting/Problem/Type.hs
+++ b/src/Data/Rewriting/Problem/Type.hs
@@ -19,6 +19,8 @@ import qualified Prelude as P
 import Data.Rewriting.Rule (Rule (..))
 import qualified Data.Rewriting.Rule as Rule
 
+import Control.Applicative
+
 data StartTerms = AllTerms
                 | BasicTerms deriving (Eq, Show)
 

--- a/src/Data/Rewriting/Rules/Rewrite.hs
+++ b/src/Data/Rewriting/Rules/Rewrite.hs
@@ -17,6 +17,7 @@ module Data.Rewriting.Rules.Rewrite (
     outerRewrite,
     innerRewrite,
     rootRewrite,
+    normalForms,
     -- * utilities not reexported from "Data.Rewriting.Rules"
     nested,
     listContexts,
@@ -93,3 +94,10 @@ listContexts :: [a] -> [(Int, a -> [a], a)]
 listContexts = go 0 id where
     go !n f [] = []
     go !n f (x:xs) = (n, f . (: xs), x) : go (n+1) (f . (x:)) xs
+
+-- | Compute normal forms: Apply a rewriting strategy until no further steps are
+-- possible, collecting all reducts that are themselves irreducible.
+normalForms :: Strategy f v v' -> Term f v -> [Term f v]
+normalForms s t = go [t] where
+    go ts = let rss = fmap s ts in
+       [t | (t, []) <- zip ts rss] ++ go (rss >>= fmap result)


### PR DESCRIPTION
A function for computing the normal forms of a given term w.r.t. a given strategy.

Question: should we avoid computing duplicate NFs? (In experiments this sometimes has a huge positive impact on the running time.) Or stay with the clearer (?) implementation?