### PR TITLE
Signature extension + PrettyPrinter modification

### DIFF
--- a/src/Data/Rewriting/Problem/Parse.hs
+++ b/src/Data/Rewriting/Problem/Parse.hs
@@ -93,6 +93,7 @@ parse = spaces >> parseDecls >> eof >> getState where
                                                         Prob.symbols = Rules.funsDL (Prob.allRules e) [] })
            <|> decl "STRATEGY"  strategy   (\ e p -> p {Prob.strategy = e})
            <|> decl "STARTTERM" startterms (\ e p -> p {Prob.startTerms = e})
+           <|> (decl "COMMENT"   comment   (\ e p -> p {Prob.comment = maybeAppend Prob.comment e p}) <?> "comment")
            <|> (par comment >>= modifyProblem . (\ e p -> p {Prob.comment = maybeAppend Prob.comment e p}) <?> "comment")
   decl name p f = try (par $ do
       lex $ string name

--- a/src/Data/Rewriting/Problem/Parse.hs
+++ b/src/Data/Rewriting/Problem/Parse.hs
@@ -71,6 +71,7 @@ fromCharStream sourcename input =
                                                                          Prob.weakRules = [] } ,
                                       Prob.variables  = [] ,
                                       Prob.symbols    = [] ,
+                                      Prob.signature  = Nothing,
                                       Prob.comment    = Nothing }
 
 
@@ -89,6 +90,7 @@ parse = spaces >> parseDecls >> eof >> getState where
   parseDecls = many1 parseDecl
   parseDecl =  decl "VAR"       vars       (\ e p -> p {Prob.variables = e `union` Prob.variables p})
            <|> decl "THEORY"    theory     (\ e p -> p {Prob.theory = maybeAppend Prob.theory e p})
+           <|> decl "SIG"       signature  (\ e p -> p {Prob.signature = maybeAppend Prob.signature e p})
            <|> decl "RULES"     rules      (\ e p -> p {Prob.rules   = e, --FIXME multiple RULES blocks?
                                                         Prob.symbols = Rules.funsDL (Prob.allRules e) [] })
            <|> decl "STRATEGY"  strategy   (\ e p -> p {Prob.strategy = e})
@@ -104,6 +106,14 @@ parse = spaces >> parseDecls >> eof >> getState where
 vars :: (Stream s (Either ProblemParseError) Char) => WSTParser s [String]
 vars = do vs <- many (lex $ ident "()," [])
           return vs
+
+signature :: (Stream s (Either ProblemParseError) Char) => WSTParser s [(String,Int)]
+signature = many fundecl
+    where
+        fundecl = par (do
+            f  <- lex $ ident "()," []
+            ar <- lex (read <$> many1 digit)
+            return $ (f,ar))
 
 theory :: (Stream s (Either ProblemParseError) Char) => WSTParser s [Prob.Theory String String]
 theory = many thdecl where

--- a/src/Data/Rewriting/Problem/Pretty.hs
+++ b/src/Data/Rewriting/Problem/Pretty.hs
@@ -35,7 +35,7 @@ prettyWST fun var prob =
   where commentblock f fpp = case f prob of
                                Just e -> parens $ fpp e
                                Nothing -> empty
-        block n pp = (parens $ hang 3 $ text n <$$> pp) <> linebreak
+        block n pp = (parens $ (hang 3 $ text n <$$> pp) <> linebreak) <> linebreak
         maybeblock n f fpp = case f prob of
                                Just e -> block n (fpp e)
                                Nothing -> empty

--- a/src/Data/Rewriting/Problem/Pretty.hs
+++ b/src/Data/Rewriting/Problem/Pretty.hs
@@ -29,6 +29,7 @@ prettyWST fun var prob =
     <> printWhen (strat /= Full) (block "STRATEGY" $ ppStrat strat)
     <> maybeblock "THEORY" theory ppTheories
     <> block "VAR" (ppVars $ variables prob)
+    <> maybeblock "SIG" signature ppSignature
     <> block "RULES" (ppRules $ rules prob)
     <> maybeblock "COMMENT" comment text
 
@@ -45,6 +46,9 @@ prettyWST fun var prob =
         ppTheories thys = align $ vcat [ppThy thy | thy <- thys]
             where ppThy (SymbolProperty p fs) = block p (align $ fillSep [ fun f | f <- fs ])
                   ppThy (Equations rs)        = block "EQUATIONS" $ vcat [ppRule "==" r | r <- rs]
+
+        ppSignature sigs = align $ fillSep [ppSig sig | sig <- sigs]
+            where ppSig (f,i) = parens $ fun f <+> int i
 
         ppRules rp = align $ vcat ([ppRule "->" r | r <- strictRules rp]
                                    ++ [ppRule "->=" r | r <- weakRules rp])

--- a/src/Data/Rewriting/Problem/Pretty.hs
+++ b/src/Data/Rewriting/Problem/Pretty.hs
@@ -30,12 +30,9 @@ prettyWST fun var prob =
     <> maybeblock "THEORY" theory ppTheories
     <> block "VAR" (ppVars $ variables prob)
     <> block "RULES" (ppRules $ rules prob)
-    <> commentblock comment text
+    <> maybeblock "COMMENT" comment text
 
-  where commentblock f fpp = case f prob of
-                               Just e -> parens $ fpp e
-                               Nothing -> empty
-        block n pp = (parens $ (hang 3 $ text n <$$> pp) <> linebreak) <> linebreak
+  where block n pp = (parens $ (hang 3 $ text n <$$> pp) <> linebreak) <> linebreak
         maybeblock n f fpp = case f prob of
                                Just e -> block n (fpp e)
                                Nothing -> empty

--- a/src/Data/Rewriting/Problem/Pretty.hs
+++ b/src/Data/Rewriting/Problem/Pretty.hs
@@ -26,13 +26,16 @@ prettyWST' = prettyWST pretty pretty
 prettyWST :: (f -> Doc) -> (v -> Doc) -> Problem f v -> Doc
 prettyWST fun var prob =
     printWhen (sterms /= AllTerms) (block "STARTTERM" $ text "CONSTRUCTOR-BASED")
-    <$$> printWhen (strat /= Full) (block "STRATEGY" $ ppStrat strat)
-    <$$> maybeblock "THEORY" theory ppTheories
-    <$$> block "VAR" (ppVars $ variables prob)
-    <$$> block "RULES" (ppRules $ rules prob)
-    <$$> maybeblock "COMMENT" comment text
+    <> printWhen (strat /= Full) (block "STRATEGY" $ ppStrat strat)
+    <> maybeblock "THEORY" theory ppTheories
+    <> block "VAR" (ppVars $ variables prob)
+    <> block "RULES" (ppRules $ rules prob)
+    <> commentblock comment text
 
-  where block n pp = parens $ hang 3 $ text n <$$> pp
+  where commentblock f fpp = case f prob of
+                               Just e -> parens $ fpp e
+                               Nothing -> empty
+        block n pp = (parens $ hang 3 $ text n <$$> pp) <> linebreak
         maybeblock n f fpp = case f prob of
                                Just e -> block n (fpp e)
                                Nothing -> empty

--- a/src/Data/Rewriting/Problem/Type.hs
+++ b/src/Data/Rewriting/Problem/Type.hs
@@ -39,6 +39,7 @@ data Problem f v = Problem { startTerms :: StartTerms
                            , rules      :: RulesPair f v
                            , variables  :: [v]
                            , symbols    :: [f]
+                           , signature  :: Maybe [(f,Int)]
                            , comment    :: Maybe String} deriving (Show)
 
 allRules :: RulesPair f v -> [Rule f v]
@@ -52,6 +53,7 @@ map ffun fvar prob =
            , rules = mapRulesPair ffun fvar (rules prob)
            , variables = P.map fvar (variables prob)
            , symbols = P.map ffun (symbols prob)
+           , signature = fmap (P.map (\(f,a) -> (ffun f, a))) (signature prob)
            , comment = comment prob}
               
 mapTheory :: (f -> f') -> (v -> v') -> Theory f v -> Theory f' v'

--- a/src/Data/Rewriting/Problem/Type.hs
+++ b/src/Data/Rewriting/Problem/Type.hs
@@ -39,7 +39,7 @@ data Problem f v = Problem { startTerms :: StartTerms
                            , rules      :: RulesPair f v
                            , variables  :: [v]
                            , symbols    :: [f]
-                           , signature  :: Maybe [(f,Int)]
+                           , signature  :: Maybe [(f, Int)]
                            , comment    :: Maybe String} deriving (Show)
 
 allRules :: RulesPair f v -> [Rule f v]
@@ -53,7 +53,7 @@ map ffun fvar prob =
            , rules = mapRulesPair ffun fvar (rules prob)
            , variables = P.map fvar (variables prob)
            , symbols = P.map ffun (symbols prob)
-           , signature = fmap (P.map (\(f,a) -> (ffun f, a))) (signature prob)
+           , signature = fmap (P.map (\(f, a) -> (ffun f, a))) (signature prob)
            , comment = comment prob}
               
 mapTheory :: (f -> f') -> (v -> v') -> Theory f v -> Theory f' v'


### PR DESCRIPTION
## Signature block addition
The Cops database uses an [extension to the TRS format](http://project-coco.uibk.ac.at/problems/trs.php) which may include a `(SIG ...)` block.
I have implemented a parser for the extension, however the parsed signature is not checked for consistency with the given TRS.

## PrettyPrinter changes

The pretty printer for the WST format previously did 2 undesirable things:
  -  print empty lines when optional blocks are empty
  -  replicate COMMENT block identifier

For example on COPS#47: 
```
(VAR x)
(RULES
  F(x,x) -> A
  G(x) -> F(x,G(x))
  C -> G(C)
)
(COMMENT
doi:10.1145/322217.322230
[12] p. 813, attributed to Barendregt
submitted by: Takahito Aoto, Junichi Yoshida, and Yoshihito Toyama
)
```
After parsing and pretty printing looks like:
```



(VAR
    x)
(RULES
    F(x,x) -> A()
    G(x) -> F(x,G(x))
    C() -> G(C()))
(COMMENT
    COMMENT
doi:10.1145/322217.322230
[12] p. 813, attributed to Barendregt
submitted by: Takahito Aoto, Junichi Yoshida, and Yoshihito Toyama
)
```
(Note the leading empty lines and the duplicated COMMENT)

Pretty printing the same problem with the new printer looks like:
```
(VAR
    x
)
(RULES
    F(x,x) -> A()
    G(x) -> F(x,G(x))
    C() -> G(C())
)
(COMMENT
    doi:10.1145/322217.322230
[12] p. 813, attributed to Barendregt
submitted by: Takahito Aoto, Junichi Yoshida, and Yoshihito Toyama

)
```