### PR TITLE
Build with latest GHCs (up to 9.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .cabal-sandbox/
 cabal.config
 cabal.sandbox.config
+/.stack-work/
+/dist-newstyle/
+/stack*.yaml.lock

--- a/src/Data/Rewriting/Problem/Parse.hs
+++ b/src/Data/Rewriting/Problem/Parse.hs
@@ -5,6 +5,7 @@
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DataKinds #-}
 module Data.Rewriting.Problem.Parse (
   parseIO,
   parseFileIO,
@@ -25,8 +26,8 @@ import Data.List (partition, union)
 import Data.Maybe (isJust)
 import Prelude hiding (lex, catch)
 import Control.Exception (catch)
-import Control.Monad.Error
-import Control.Monad (liftM, liftM3)
+import Control.Monad.Except
+import Control.Monad (liftM, liftM2, liftM3, mzero)
 import Text.Parsec hiding (parse)
 import System.IO (readFile)
 
@@ -36,7 +37,7 @@ data ProblemParseError = UnknownParseError String
                        | UnsupportedDeclaration String
                        | SomeParseError ParseError deriving (Show)
 
-instance Error ProblemParseError where strMsg = UnknownParseError
+-- instance Error ProblemParseError where strMsg = UnknownParseError
 
 parseFileIO :: FilePath -> IO (Problem String String)
 parseFileIO file = do r <- fromFile file

--- a/src/Data/Rewriting/Problem/Pretty.hs
+++ b/src/Data/Rewriting/Problem/Pretty.hs
@@ -13,17 +13,25 @@ import Data.Maybe (isJust, fromJust)
 import Data.List (nub)
 import Data.Rewriting.Problem.Type
 import Data.Rewriting.Rule (prettyRule)
-import Text.PrettyPrint.ANSI.Leijen
+-- import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter
 
-printWhen :: Bool -> Doc -> Doc
-printWhen False _ = empty
+printWhen :: Bool -> Doc ann -> Doc ann
+printWhen False _ = pretty ""
 printWhen True  p = p
 
+text = pretty
+empty = text ""
+linebreak = flatAlt line empty
+int = text . show
+underline =  id
 
-prettyWST' :: (Pretty f, Pretty v) => Problem f v -> Doc
+x <$$> y = x <> linebreak <> y
+
+prettyWST' :: (Pretty f, Pretty v) => Problem f v -> Doc ann
 prettyWST' = prettyWST pretty pretty
 
-prettyWST :: (f -> Doc) -> (v -> Doc) -> Problem f v -> Doc
+prettyWST :: (f -> Doc ann) -> (v -> Doc ann) -> Problem f v -> Doc ann
 prettyWST fun var prob =
     printWhen (sterms /= AllTerms) (block "STARTTERM" $ text "CONSTRUCTOR-BASED")
     <> printWhen (strat /= Full) (block "STRATEGY" $ ppStrat strat)
@@ -33,7 +41,7 @@ prettyWST fun var prob =
     <> block "RULES" (ppRules $ rules prob)
     <> maybeblock "COMMENT" comment text
 
-  where block n pp = (parens $ (hang 3 $ text n <$$> pp) <> linebreak) <> linebreak
+  where block n pp = (parens $ (hang 3 $ text n <> linebreak <> pp) <> linebreak) <> linebreak
         maybeblock n f fpp = case f prob of
                                Just e -> block n (fpp e)
                                Nothing -> empty
@@ -60,7 +68,7 @@ prettyWST fun var prob =
         thry   = theory prob
 
 
-prettyProblem :: (Eq f, Eq v) => (f -> Doc) -> (v -> Doc) -> Problem f v -> Doc
+prettyProblem :: (Eq f, Eq v) => (f -> Doc ann) -> (v -> Doc ann) -> Problem f v -> Doc ann
 prettyProblem fun var prob =  block "Start-Terms" (ppST `on` startTerms)
                               <$$> block "Strategy" (ppStrat `on` strategy)
                               <$$> block "Variables" (ppVars `on` variables)

--- a/src/Data/Rewriting/Rule/Pretty.hs
+++ b/src/Data/Rewriting/Rule/Pretty.hs
@@ -10,12 +10,13 @@ module Data.Rewriting.Rule.Pretty (
 import Data.Rewriting.Rule.Type
 import Data.Rewriting.Term (prettyTerm)
 
-import Text.PrettyPrint.ANSI.Leijen
+--import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter
 
-prettyRule :: Doc -> (f -> Doc) -> (v -> Doc) -> Rule f v -> Doc
-prettyRule arr fun var (Rule l r) = hang 2 $ term l <+> arr </> term r where
+prettyRule :: Doc ann -> (f -> Doc ann) -> (v -> Doc ann) -> Rule f v -> Doc ann
+prettyRule arr fun var (Rule l r) = hang 2 $ term l <+> arr <> softline <> term r where
     term = prettyTerm fun var
 
 instance (Pretty f, Pretty v) => Pretty (Rule f v) where
-    pretty = prettyRule (text "->") pretty pretty
+    pretty = prettyRule (pretty "->") pretty pretty
 

--- a/src/Data/Rewriting/Substitution/Pretty.hs
+++ b/src/Data/Rewriting/Substitution/Pretty.hs
@@ -12,14 +12,15 @@ import Data.Rewriting.Substitution.Type
 import Data.Rewriting.Term (prettyTerm)
 import qualified Data.Map as M
 
-import Text.PrettyPrint.ANSI.Leijen
+-- import Text.PrettyPrint.ANSI.Leijen (text)
+import Prettyprinter
 
-prettyGSubst :: (v -> Doc) -> (f -> Doc) -> (v' -> Doc) -> GSubst v f v' -> Doc
+prettyGSubst :: (v -> Doc ann) -> (f -> Doc ann) -> (v' -> Doc ann) -> GSubst v f v' -> Doc ann
 prettyGSubst var fun var' subst =
     encloseSep lbrace rbrace comma [ppBinding v t | (v,t) <- M.toList $ toMap subst]
-    where ppBinding v t = var v <> text "/" <> prettyTerm fun var' t
+    where ppBinding v t = var v <> pretty "/" <> prettyTerm fun var' t
 
-prettySubst :: (f -> Doc) -> (v -> Doc) -> Subst f v -> Doc
+prettySubst :: (f -> Doc ann) -> (v -> Doc ann) -> Subst f v -> Doc ann
 prettySubst fun var = prettyGSubst var fun var
 
 instance (Pretty v, Pretty f, Pretty v') => Pretty (GSubst v f v') where

--- a/src/Data/Rewriting/Substitution/Unify.hs
+++ b/src/Data/Rewriting/Substitution/Unify.hs
@@ -21,6 +21,7 @@ import qualified Control.Monad.Union as UM
 import qualified Data.Union as U
 import Control.Monad.State
 import Control.Monad.ST
+import Control.Monad
 import Control.Applicative
 import Control.Arrow
 import Data.Array.ST

--- a/src/Data/Rewriting/Term/Pretty.hs
+++ b/src/Data/Rewriting/Term/Pretty.hs
@@ -8,15 +8,16 @@ module Data.Rewriting.Term.Pretty (
 ) where
 
 import Data.Rewriting.Term.Type
-import Text.PrettyPrint.ANSI.Leijen
+--import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter
 
 -- | Given a pretty printer @f@ for function symbols and pretty printer @v@ for variables
 -- @prettyTerm f v@ produces a pretty printer for terms
 
-prettyTerm :: (f -> Doc) -> (v -> Doc) -> Term f v -> Doc
+prettyTerm :: (f -> Doc ann) -> (v -> Doc ann) -> Term f v -> Doc ann
 prettyTerm _         var (Var x) = var x
 prettyTerm fun var (Fun f ts)    = fun f <> args where
     args = encloseSep lparen rparen comma [prettyTerm fun var ti | ti <- ts]
 
 instance (Pretty f, Pretty v) => Pretty (Term f v) where
-    pretty = prettyTerm pretty pretty
+    pretty t = prettyTerm pretty pretty t

--- a/term-rewriting.cabal
+++ b/term-rewriting.cabal
@@ -70,7 +70,7 @@ library
         union-find-array >= 0.1 && < 0.2,
         array >= 0.3 && < 0.6,
         ansi-wl-pprint >= 0.6 && < 0.7,
-        mtl >= 1.1 && < 2.3,
+        mtl >= 1.1 && < 2.4,
         base >= 4 && < 5
     default-language: Haskell2010
     default-extensions:

--- a/term-rewriting.cabal
+++ b/term-rewriting.cabal
@@ -64,7 +64,7 @@ library
         Data.Rewriting.Utils
         Data.Rewriting.Utils.Parse
     build-depends:
-        containers >= 0.3 && < 0.7,
+        containers >= 0.3 && < 0.8,
         multiset >= 0.2 && < 0.4,
         parsec >= 3.1.6 && < 3.2,
         union-find-array >= 0.1 && < 0.2,
@@ -95,5 +95,5 @@ test-suite test
         term-rewriting,
         containers,
         HUnit >= 1.2 && < 1.7,
-        QuickCheck >= 2.6 && < 2.14
+        QuickCheck >= 2.6 && < 2.16
     default-language: Haskell2010

--- a/term-rewriting.cabal
+++ b/term-rewriting.cabal
@@ -1,3 +1,4 @@
+cabal-version: >= 1.10
 name:          term-rewriting
 version:       0.4.0.2
 stability:     experimental
@@ -11,20 +12,19 @@ license:       MIT
 license-file:  LICENSE
 category:      Logic
 synopsis:      Term Rewriting Library
-description:   
+description:
   Yet Another Term Rewriting Library.
   .
   This library provides basic data types and functionality for first order
   term rewriting.
 build-type:    Simple
-cabal-version: >= 1.8
 
 extra-source-files:
     Changelog
 
 source-repository head
     type: git
-    location: git://github.com/haskell-rewriting/term-rewriting
+    location: https://github.com/haskell-rewriting/term-rewriting
 
 library
     hs-source-dirs:
@@ -32,7 +32,7 @@ library
     exposed-modules:
         Data.Rewriting.Term
         Data.Rewriting.Term.Type
-        Data.Rewriting.Term.Ops 
+        Data.Rewriting.Term.Ops
         Data.Rewriting.Term.Parse
         Data.Rewriting.Term.Pretty
         Data.Rewriting.Pos
@@ -72,7 +72,8 @@ library
         ansi-wl-pprint >= 0.6 && < 0.7,
         mtl >= 1.1 && < 2.3,
         base >= 4 && < 5
-    extensions:
+    default-language: Haskell2010
+    default-extensions:
         TypeSynonymInstances
         BangPatterns
 
@@ -89,8 +90,9 @@ test-suite test
         Substitution
         Term
     build-depends:
-        base >= 4 && < 5,
+        base,
         term-rewriting,
-        containers >= 0.3 && < 0.7,
+        containers,
         HUnit >= 1.2 && < 1.7,
         QuickCheck >= 2.6 && < 2.14
+    default-language: Haskell2010

--- a/term-rewriting.cabal
+++ b/term-rewriting.cabal
@@ -69,7 +69,8 @@ library
         parsec >= 3.1.6 && < 3.2,
         union-find-array >= 0.1 && < 0.2,
         array >= 0.3 && < 0.6,
-        ansi-wl-pprint >= 0.6 && < 0.7,
+        prettyprinter >= 1.7.0 && < 2,
+        prettyprinter-compat-ansi-wl-pprint >= 1.0.1 && < 2,
         mtl >= 1.1 && < 2.4,
         base >= 4 && < 5
     default-language: Haskell2010


### PR DESCRIPTION
This PR is mostly the code by @junjihashimoto from fork https://github.com/hasktorch/term-rewriting.
I reorganized the commit so that version bumps are packaged with the respective code changes.
Further, I switched the cabal file to cabal-version 1.10 so that hackage will accept a publication.

- **.cabal file: switch to cabal-version 1.10, remove redundant constraints**
- **Allow mtl-2.3**
- **Switch to prettyprinter library**
- **Bump containers and QuickCheck**

@int-e I did not include a CI this time, but let me know if you want one.